### PR TITLE
Update ssacl.js

### DIFF
--- a/lib/ssacl.js
+++ b/lib/ssacl.js
@@ -45,7 +45,7 @@ module.exports = function(target, options) {
   assert(options.paranoia === true || options.paranoia === false, "paranoia must be true or false");
 
   if (options.cls) {
-    Sequelize.cls = options.cls;
+    Sequelize.useCLS(options.cls);
   }
 
   if (target instanceof Sequelize.Model) {


### PR DESCRIPTION
sequelize deprecated Sequelize.cls should not be set directly. Use Sequelize.useCLS()